### PR TITLE
Fix Logto post-login redirect to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ npm run dev
 
 Akses aplikasi di `http://localhost:3000`. Pastikan Anda telah mengatur aplikasi Logto dengan redirect URL `http://localhost:3000/callback`.
 
+### Debug alur masuk Logto
+
+Tambahkan parameter `?debug` pada halaman `/sign-in` atau `/callback/continue` untuk melihat snapshot state autentikasi (nilai cookie redirect, query yang terbaca, hingga tujuan akhir yang akan dipakai). Mode debug menonaktifkan pengalihan otomatis sehingga Anda bisa menelusuri langkah demi langkah sebelum melanjutkan secara manual.
+
 ## Build Production
 
 ```bash

--- a/composables/use-logto-session.ts
+++ b/composables/use-logto-session.ts
@@ -14,7 +14,7 @@ const SIGN_IN_PATH = '/sign-in'
 const SIGN_OUT_PATH = '/sign-out'
 const CALLBACK_PATH = '/callback'
 const REDIRECT_QUERY_KEY = 'redirect'
-export function useLogto() {
+export function useLogtoSession() {
   const rawUser = useLogtoUser()
   const runtimeConfig = useRuntimeConfig()
   const { logtoCookieSecure = false } = runtimeConfig.public ?? {}

--- a/lib/logto/constants.ts
+++ b/lib/logto/constants.ts
@@ -1,0 +1,15 @@
+export const LOGTO_REDIRECT_COOKIE = 'logto:redirect-path' as const
+export const LOGTO_REDIRECT_FALLBACK = '/chat' as const
+export const LOGTO_POST_CALLBACK_REDIRECT = '/callback/continue' as const
+
+export const LOGTO_RESERVED_REDIRECT_PREFIXES = [
+  '/sign-in',
+  '/sign-out',
+  '/callback',
+  LOGTO_POST_CALLBACK_REDIRECT
+] as const
+
+export const isReservedRedirectPath = (pathname: string) =>
+  LOGTO_RESERVED_REDIRECT_PREFIXES.some(prefix =>
+    pathname === prefix || pathname.startsWith(`${prefix}?`)
+  )

--- a/lib/logto/constants.ts
+++ b/lib/logto/constants.ts
@@ -1,4 +1,7 @@
+import type { CookieOptions } from 'h3'
+
 export const LOGTO_REDIRECT_COOKIE = 'logto:redirect-path' as const
+export const LOGTO_REDIRECT_COOKIE_MAX_AGE = 60 * 10
 export const LOGTO_REDIRECT_FALLBACK = '/chat' as const
 export const LOGTO_POST_CALLBACK_REDIRECT = '/callback/continue' as const
 
@@ -13,3 +16,10 @@ export const isReservedRedirectPath = (pathname: string) =>
   LOGTO_RESERVED_REDIRECT_PREFIXES.some(prefix =>
     pathname === prefix || pathname.startsWith(`${prefix}?`)
   )
+
+export const createRedirectCookieOptions = (secure: boolean): CookieOptions => ({
+  sameSite: 'lax',
+  path: '/',
+  secure,
+  maxAge: LOGTO_REDIRECT_COOKIE_MAX_AGE
+})

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,7 +1,14 @@
-export default defineNuxtRouteMiddleware(to => {
+import { abortNavigation } from '#app'
+
+export default defineNuxtRouteMiddleware(async to => {
   const { isAuthenticated, signIn } = useLogto()
 
   if (!isAuthenticated.value) {
+    if (process.client) {
+      await signIn(to.fullPath)
+      return abortNavigation()
+    }
+
     return signIn(to.fullPath)
   }
 })

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { abortNavigation } from '#app'
 
 export default defineNuxtRouteMiddleware(async to => {
-  const { isAuthenticated, signIn } = useLogto()
+  const { isAuthenticated, signIn } = useLogtoSession()
 
   if (!isAuthenticated.value) {
     if (process.client) {

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,14 +1,41 @@
-import { abortNavigation } from '#app'
+// /middleware/auth.ts
+import { abortNavigation, navigateTo } from '#app'
 
-export default defineNuxtRouteMiddleware(async to => {
-  const { isAuthenticated, signIn } = useLogtoSession()
+export default defineNuxtRouteMiddleware(async (to) => {
+  // 1) Allow public routes
+    const publicPaths = ['/', '/sign-in', '/callback', '/callback/continue']
+  if (publicPaths.some(p => to.path.startsWith(p))) return
+
+  // 2) Never call signIn() on the server.
+  //    If you want SSR redirect, send to a public /login page instead.
+  if (process.server) {
+    // (Optional) If you can read your session cookie here, do it.
+    // Otherwise just push to /login and let the client do signIn().
+    return navigateTo('/login', { redirectCode: 302 })
+  }
+
+  // 3) Client-side: wait for session hydration before deciding
+  const { isAuthenticated, isLoading, signIn } = useLogtoSession() as {
+    isAuthenticated: Ref<boolean>
+    isLoading?: Ref<boolean>
+    signIn: (returnTo?: string) => Promise<void>
+  }
+
+  // Avoid eager redirect while the SDK is still hydrating
+  if (isLoading?.value) {
+    // wait a tick or two
+    while (isLoading.value) {
+      await new Promise(r => requestAnimationFrame(r))
+    }
+  }
 
   if (!isAuthenticated.value) {
-    if (process.client) {
-      await signIn(to.fullPath)
+    // Guard against double-calls
+    if (typeof window !== 'undefined' && (window as any).__logtoRedirecting) {
       return abortNavigation()
     }
-
-    return signIn(to.fullPath)
+    ;(window as any).__logtoRedirecting = true
+    await signIn(to.fullPath)
+    return abortNavigation()
   }
 })

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,8 +1,7 @@
-export default defineNuxtRouteMiddleware((to, from) => {
-  const { isAuthenticated } = useLogto()
-  
-  // If user is not authenticated, redirect to home page
+export default defineNuxtRouteMiddleware(to => {
+  const { isAuthenticated, signIn } = useLogto()
+
   if (!isAuthenticated.value) {
-    return navigateTo('/')
+    return signIn(to.fullPath)
   }
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,7 +50,8 @@ export default defineNuxtConfig({
     // Public keys (exposed to client-side)
     public: {
       logtoEndpoint: process.env.LOGTO_ENDPOINT,
-      logtoAppId: process.env.LOGTO_APP_ID
+      logtoAppId: process.env.LOGTO_APP_ID,
+      logtoCookieSecure: process.env.NODE_ENV === 'production'
     }
   }
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { LOGTO_POST_CALLBACK_REDIRECT } from './lib/logto/constants'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
@@ -39,7 +41,7 @@ export default defineNuxtConfig({
       appId: process.env.LOGTO_APP_ID,
       appSecret: process.env.LOGTO_APP_SECRET,
       cookieEncryptionKey: process.env.LOGTO_COOKIE_ENCRYPTION_KEY,
-      postCallbackRedirectUri: '/chat',
+      postCallbackRedirectUri: LOGTO_POST_CALLBACK_REDIRECT,
       postLogoutRedirectUri: '/',
       cookieSecure: process.env.NODE_ENV === 'production',
       customRedirectBaseUrl: process.env.LOGTO_BASE_URL ?? 'http://localhost:3000'

--- a/pages/callback/continue.vue
+++ b/pages/callback/continue.vue
@@ -13,7 +13,7 @@ const redirectCookie = useCookie<string | null>(
   LOGTO_REDIRECT_COOKIE,
   createRedirectCookieOptions(logtoCookieSecure)
 )
-const { isAuthenticated } = useLogto()
+const { isAuthenticated } = useLogtoSession()
 
 const hasError = computed(() => typeof route.query.error === 'string')
 const isDebugMode = computed(() => 'debug' in route.query)

--- a/pages/callback/continue.vue
+++ b/pages/callback/continue.vue
@@ -13,6 +13,7 @@ const redirectCookie = useCookie<string | null>(
   LOGTO_REDIRECT_COOKIE,
   createRedirectCookieOptions(logtoCookieSecure)
 )
+const { isAuthenticated } = useLogto()
 
 const hasError = computed(() => typeof route.query.error === 'string')
 const isDebugMode = computed(() => 'debug' in route.query)
@@ -22,7 +23,8 @@ const debugState = computed(() => ({
   errorDescription: errorDescription.value,
   storedRedirectCookie: redirectCookie.value,
   redirectQuery: route.query.redirect ?? null,
-  resolvedRedirect: resolvedRedirect.value
+  resolvedRedirect: resolvedRedirect.value,
+  isAuthenticated: isAuthenticated.value
 }))
 const debugSnapshot = computed(() => JSON.stringify(debugState.value, null, 2))
 const errorDescription = computed(() => {
@@ -61,6 +63,13 @@ onMounted(() => {
       ...debugState.value,
       timestamp: new Date().toISOString()
     })
+    return
+  }
+
+  if (!isAuthenticated.value) {
+    console.warn('[Logto][callback] Missing authenticated session during callback continue redirect')
+    redirectCookie.value = null
+    navigateTo(LOGTO_REDIRECT_FALLBACK, { replace: true })
     return
   }
 

--- a/pages/callback/continue.vue
+++ b/pages/callback/continue.vue
@@ -15,6 +15,16 @@ const redirectCookie = useCookie<string | null>(
 )
 
 const hasError = computed(() => typeof route.query.error === 'string')
+const isDebugMode = computed(() => 'debug' in route.query)
+const debugState = computed(() => ({
+  hasError: hasError.value,
+  error: route.query.error ?? null,
+  errorDescription: errorDescription.value,
+  storedRedirectCookie: redirectCookie.value,
+  redirectQuery: route.query.redirect ?? null,
+  resolvedRedirect: resolvedRedirect.value
+}))
+const debugSnapshot = computed(() => JSON.stringify(debugState.value, null, 2))
 const errorDescription = computed(() => {
   if (!hasError.value) {
     return ''
@@ -43,6 +53,14 @@ let redirectTimer: ReturnType<typeof setTimeout> | undefined
 onMounted(() => {
   if (hasError.value) {
     redirectCookie.value = null
+    return
+  }
+
+  if (isDebugMode.value) {
+    console.debug('[Logto][callback] Debug snapshot', {
+      ...debugState.value,
+      timestamp: new Date().toISOString()
+    })
     return
   }
 
@@ -99,6 +117,17 @@ onBeforeUnmount(() => {
       >
         Buka sekarang
       </NuxtLink>
+
+      <div
+        v-if="isDebugMode"
+        class="bg-gray-50 border border-gray-200 text-left text-xs font-mono px-4 py-3 rounded-lg space-y-2"
+      >
+        <span class="text-gray-600 font-semibold">Debug mode aktif</span>
+        <pre class="whitespace-pre-wrap text-gray-700">{{ debugSnapshot }}</pre>
+        <p class="text-gray-500">
+          Navigasi otomatis dinonaktifkan. Gunakan tautan manual di atas untuk melanjutkan.
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/pages/callback/continue.vue
+++ b/pages/callback/continue.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
-import { LOGTO_REDIRECT_COOKIE, LOGTO_REDIRECT_FALLBACK, isReservedRedirectPath } from '~/lib/logto/constants'
+import {
+  LOGTO_REDIRECT_COOKIE,
+  LOGTO_REDIRECT_FALLBACK,
+  createRedirectCookieOptions,
+  isReservedRedirectPath
+} from '~/lib/logto/constants'
 
 const route = useRoute()
-const redirectCookie = useCookie<string | null>(LOGTO_REDIRECT_COOKIE, {
-  sameSite: 'lax',
-  secure: process.env.NODE_ENV === 'production',
-  path: '/',
-  maxAge: 60 * 10
-})
+const runtimeConfig = useRuntimeConfig()
+const { logtoCookieSecure = false } = runtimeConfig.public ?? {}
+const redirectCookie = useCookie<string | null>(
+  LOGTO_REDIRECT_COOKIE,
+  createRedirectCookieOptions(logtoCookieSecure)
+)
 
 const hasError = computed(() => typeof route.query.error === 'string')
 const errorDescription = computed(() => {

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -6,7 +6,7 @@ definePageMeta({
 })
 
 // Authentication
-const { signOut, user } = useLogto()
+const { signOut, user } = useLogtoSession()
 
 // Reactive state
 const chatSessions = ref([])

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -6,12 +6,7 @@ definePageMeta({
 })
 
 // Authentication
-const { isAuthenticated, signOut, user } = useLogto()
-
-// Redirect if not authenticated
-if (!isAuthenticated.value) {
-  await navigateTo('/')
-}
+const { signOut, user } = useLogto()
 
 // Reactive state
 const chatSessions = ref([])

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,26 +2,20 @@
   <div class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
     <div class="max-w-md w-full space-y-8 p-8">
       <div class="text-center">
-        <h1 class="text-4xl font-bold text-gray-900 mb-2">
-          Gemini Chatbot
-        </h1>
-        <p class="text-gray-600 mb-8">
-          Berinteraksi dengan AI menggunakan Google Gemini 2.5 Pro
-        </p>
-        
+        <h1 class="text-4xl font-bold text-gray-900 mb-2">Gemini Chatbot</h1>
+        <p class="text-gray-600 mb-8">Berinteraksi dengan AI menggunakan Google Gemini 2.5 Pro</p>
+
         <div v-if="!isAuthenticated" class="space-y-4">
           <button
-            @click="signIn"
+            @click="handleSignIn"
             class="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-lg transition-colors"
           >
             Masuk dengan Logto
           </button>
         </div>
-        
+
         <div v-else class="space-y-4">
-          <p class="text-green-600 font-medium">
-            Selamat datang kembali!
-          </p>
+          <p class="text-green-600 font-medium">Selamat datang kembali!</p>
           <button
             @click="navigateTo('/chat')"
             class="w-full bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-4 rounded-lg transition-colors"
@@ -34,20 +28,20 @@
   </div>
 </template>
 
-<script setup>
-import { useLogtoUser } from '#imports';
+<script setup lang="ts">
+import { useLogtoUser, useLogtoSession } from '#imports'
 
-const user = useLogtoUser();
-const isAuthenticated = computed(() => Boolean(user?.value));
+const user = useLogtoUser()
+const isAuthenticated = computed(() => Boolean(user?.value))
 
-const signIn = () => {
-  navigateTo('/sign-in');
-};
+const { signIn } = useLogtoSession()
+const handleSignIn = () => {
+  // after login, return to /chat
+  signIn('/chat')
+}
 
-// Redirect authenticated users to chat
+// Optional: auto-redirect when already logged in
 watchEffect(() => {
-  if (isAuthenticated.value) {
-    navigateTo('/chat');
-  }
-});
+  if (isAuthenticated.value) navigateTo('/chat')
+})
 </script>

--- a/pages/sign-in.vue
+++ b/pages/sign-in.vue
@@ -1,12 +1,17 @@
 <script setup>
+import { LOGTO_REDIRECT_FALLBACK, isReservedRedirectPath } from '~/lib/logto/constants'
+
 const { isAuthenticated, signIn } = useLogto()
 const route = useRoute()
 
 const redirectPath = computed(() => {
   const redirect = route.query.redirect
-  return typeof redirect === 'string' && redirect.startsWith('/')
-    ? redirect
-    : '/chat'
+
+  if (typeof redirect === 'string' && redirect.startsWith('/') && !isReservedRedirectPath(redirect)) {
+    return redirect
+  }
+
+  return LOGTO_REDIRECT_FALLBACK
 })
 
 const errorMessage = ref('')

--- a/pages/sign-in.vue
+++ b/pages/sign-in.vue
@@ -6,7 +6,7 @@ import {
   isReservedRedirectPath
 } from '~/lib/logto/constants'
 
-const { isAuthenticated, signIn } = useLogto()
+const { isAuthenticated, signIn } = useLogtoSession()
 const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 const { logtoCookieSecure = false } = runtimeConfig.public ?? {}


### PR DESCRIPTION
## Summary
- update the auth middleware to send unauthenticated visitors to the Logto sign-in flow with their intended return path
- rely on the middleware to guard the chat page to prevent an extra client-side redirect after login

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cb7aea00833292d3e8d917cb206a